### PR TITLE
Fix CircleCI workflow syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,10 +78,15 @@ workflows:
               only:
                 - development
                 - master
+  cron:
+    jobs:
+      - test
+      - lint
+      - audit
     triggers:
       - schedule:
-        cron: "0 13 * * *"
-        filters:
-          branches:
-            only:
-              - master
+          cron: "0 13 * * *"
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
This applies the same fix as https://github.com/carbonfive/spraygun-express/pull/85 in order to fix scheduled Circle CI builds.

Tested the syntax locally:

```
$ circleci config validate
Config file at .circleci/config.yml is valid.
```