### PR TITLE
Always install the latest deps in CI cron job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-          - run: yarn install
+            - run: yarn install
   lint:
     executor:
       name: node/default
@@ -20,7 +20,7 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-          - run: yarn lint
+            - run: yarn lint
   unit_tests:
     executor:
       name: node/default
@@ -29,14 +29,14 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-          - run:
-              name: yarn test
-              command: yarn test:coverage --ci --color --reporters=default --reporters=jest-junit --runInBand
-              environment:
-                JEST_JUNIT_OUTPUT_DIR: ./tmp/test-results
-                JEST_JUNIT_OUTPUT_NAME: jest.xml
-          - store_test_results:
-              path: ./tmp/test-results
+            - run:
+                name: yarn test
+                command: yarn test:coverage --ci --color --reporters=default --reporters=jest-junit --runInBand
+                environment:
+                  JEST_JUNIT_OUTPUT_DIR: ./tmp/test-results
+                  JEST_JUNIT_OUTPUT_NAME: jest.xml
+            - store_test_results:
+                path: ./tmp/test-results
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,13 @@ workflows:
             - install_deps
   cron:
     jobs:
-      - unit_tests
-      - lint
+      - install_deps
+      - lint:
+          requires:
+            - install_deps
+      - unit_tests:
+          requires:
+            - install_deps
     triggers:
       - schedule:
           cron: "0 13 * * *"


### PR DESCRIPTION
Make sure to run `install_deps` during the cron-based builds so that we can leverage scheduled builds to monitor when new versions of dependencies cause this project to break.

Also: reformat the `.circleci/config.yml` file with Prettier.