### PR TITLE
Fix failing CircleCI cron workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,13 @@ workflows:
             - install_deps
   cron:
     jobs:
-      - unit_tests
-      - lint
+      - install_deps
+      - lint:
+          requires:
+            - install_deps
+      - unit_tests:
+          requires:
+            - install_deps
     triggers:
       - schedule:
           cron: "0 13 * * *"


### PR DESCRIPTION
Problem
=======
The cron workflow is currently failing because of missing dependencies:

https://circleci.com/gh/carbonfive/spraygun-react/1161

Solution
========

Fix by ensuring that the `install_deps` job is run in the cron workflow.

I verified the CircleCI syntax with:

```
$ circleci config validate
Config file at .circleci/config.yml is valid.
```
