### PR TITLE
Require Node >= 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a Carbon Five-flavored convenience skeleton project for React. It is bas
 - Deployable to Heroku out of the box
 - Or deploy via docker using the included Dockerfile
 
-To get started, make sure you have Node 8.10+ and Yarn installed, and then generate your project like this:
+To get started, make sure you have Node 10+ and Yarn installed, and then generate your project like this:
 
 ```
 $ npx spraygun -t react <project-directory>


### PR DESCRIPTION
The spraygun CLI now requires Node >= 10, so we need to recommend that here as well.
