### PR TITLE
Clarify which dependabot strategy should be used

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
       time: "14:00"
       timezone: America/Los_Angeles
     open-pull-requests-limit: 10
+    versioning-strategy: increase-if-necessary


### PR DESCRIPTION
By default, dependabot will only update dependencies within the ranges allowed in `package.json`. For this project we always want the latest versions. In other words, the `increase-if-necessary` strategy.

https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates#versioning-strategy